### PR TITLE
Python 2.6 에서 동작 확인 / 대회 전체 리스트 API 추가

### DIFF
--- a/app2.py
+++ b/app2.py
@@ -41,7 +41,7 @@ def contest_list():
 def contest_list_all():
   try:
     r = getRedis()
-    contest_list = [ r.hgetall('contest_info:{0}'.format(_)) for _ in r.smembers('contests') ]
+    contest_list = [ r.hgetall(_) for _ in r.keys('contest_info:*') ]
     return jsonify(contest_list=contest_list, code='ok')
   except Exception, e:
     print sys.exc_info()[0], e

--- a/crawler2.py
+++ b/crawler2.py
@@ -118,7 +118,6 @@ def updateContestInfo(rival_id):
           cur_key = 'current_contest:' + contest_info['id']
           r.set(cur_key, 1)
           r.expireat(cur_key, dateToTime(contest_info['end'])+600)
-          r.sadd('contests', contest_info['id'])
 
   except Exception, e:
     logging.error('updateContestInfo Error: %s(%d)'%(e, rival_id))


### PR DESCRIPTION
contest_info 는 그냥 남아있길래 contest_info 를 읽어와서 전체 리스트를 만들었습니다.
소트나 페이징도 해야 할 것 같지만 일단..

Python 2.6에서는 '{}'.format(1) 등이 동작하지 않습니다.
따라서 '{0}'.format(1) 과 같이 고쳤고, 2.7.2에서 동작 함을 확인하였습니다.
