### PR TITLE
Now score updates are smoother

### DIFF
--- a/crawler3.py
+++ b/crawler3.py
@@ -351,6 +351,7 @@ def getUserScore(rival_id):
       logging.error("getUserScore Error: site is not availabe.")
       return []
 
+
     playScore = []
     hashData = {}
     pages = []
@@ -366,6 +367,7 @@ def getUserScore(rival_id):
         logging.error("getUserScore Error: site is not availabe.")
         return []
       pages.append(page)
+
 
     for page in pages:
         oddrows = page.findAll(attrs={"class":"odd"})


### PR DESCRIPTION
새로운 곡을 플레이했을 때 제대로 첫플 기갱이 표시됨...
ex)
Before:
[누구누구]님의 스코어가 업데이트 되었습니다.
970000 (-20000) 
990000 (0)
980000 (-10000)
After:
970000 (+970000)
990000 (+20000)
980000 (-10000)
music_id 라는 해쉬를 만들었으니, 새로운 곡마다 스코어를 모조리 긁는 낭비는 안해도 되도록 함.

덤으로 sirc 로 잘 보이도록 기갱 점수에 검은 배경을 넣음

////

오후 12시에 추가:
4.8 오전 7시에 수정:
주의!!!!!
실행 코드에 추가해야할 것

crawler3.getUserScore(rival_id) : 이걸 반드시해야 rival_id 의 스코어가 8자리 music_id 를 갖고 있을 수 있다.
crawler3.initMusicTable(rival_id) : music_id 테이블을 init 하는게 있어야하고, 반드시 위에서 사용한 rival_id 를 사용해야한다!

crawler3.syncMusicID(all rival_id) : 지금 코드가 잘못 되어있어서 8자리 숫자여야하는 music_id가 7자리만 긁어옴. 모든 등록된 id를 대상으로 이걸 수행해야 제대로 된 8자리 숫자로 바뀌어 들어간다. (물론 7자리 수를 긁는 코드는 8자리 긁어오도록 고침)
